### PR TITLE
Enlarge portfolio imagery for mobile viewing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1306,7 +1306,7 @@ section {
 /* Masonry-style image grid */
 .image-grid {
     /* Base styles for all grids */
-    width: 80%; /* Wider container for better layout */
+    width: min(100%, 1100px); /* Allow images to use more horizontal space */
     margin: 0 auto 0.5rem auto; /* Reduced bottom margin */
     position: relative;
     z-index: 1; /* Above the background slideshow */
@@ -1354,7 +1354,7 @@ section {
 #portfolio-display .live-music-grid.active,
 #portfolio-display .visuals-grid.active {
     display: grid; /* Use grid instead of flex */
-    grid-template-columns: repeat(2, 1fr); /* Always 2 columns */
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); /* Responsive column sizing */
     gap: 2.5rem; /* Increased spacing */
     justify-content: center;
     margin: 0 auto; /* Center the entire grid */
@@ -1376,7 +1376,7 @@ section {
 /* Always maintain two columns */
 @media (min-width: 992px) {
     .image-grid {
-        width: 70%; /* Maintain consistent width */
+        width: min(95%, 1100px); /* Use more available space on larger screens */
         grid-template-columns: repeat(2, 1fr); /* Always 2 columns */
         gap: 2.5rem; /* Increased spacing for better separation */
     }
@@ -1473,9 +1473,9 @@ section {
 /* Responsive adjustments */
 @media (max-width: 1200px) {
     .image-grid {
-        grid-template-columns: repeat(2, 1fr); /* Two columns */
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); /* Responsive columns */
         gap: 2.5rem; /* Increased spacing */
-        width: 80%;
+        width: min(95%, 900px);
     }
     .image-grid .grid-item {
         width: 100%; /* Full width within grid cell */
@@ -1484,31 +1484,35 @@ section {
 
 @media (max-width: 768px) {
     .image-grid {
-        width: 90%; /* Use more screen width on mobile */
-        grid-template-columns: repeat(2, 1fr); /* Enforce two columns */
+        width: 95%; /* Use more screen width on mobile */
+        grid-template-columns: 1fr; /* Display items in a single column */
         display: grid; /* Use grid for consistent layout */
-        gap: 2.5rem; /* Increased spacing to prevent overlap */
+        gap: 2rem; /* Comfortable spacing for larger images */
         margin: 0 auto; /* Center the grid */
     }
     .image-grid .grid-item {
         width: 100%; /* Let grid control the width */
         margin-bottom: 0; /* Remove bottom margin as gap is used now */
     }
+    #portfolio-display .live-music-grid.active,
+    #portfolio-display .visuals-grid.active {
+        grid-template-columns: 1fr; /* Ensure single column in active grids */
+    }
 }
 
 @media (max-width: 480px) {
     .image-grid {
-        width: 95%; /* Use even more screen width on very small devices */
-        grid-template-columns: repeat(2, 1fr); /* Always 2 columns even on small screens */
-        gap: 2.5rem; /* Increased spacing to prevent overlap */
+        width: 100%; /* Allow images to stretch edge-to-edge */
+        grid-template-columns: 1fr; /* Single column on compact screens */
+        gap: 1.75rem; /* Slightly tighter gap for narrow viewports */
     }
     .image-grid .grid-item {
         width: 100%; /* Let grid control the width */
         margin-bottom: 0; /* Remove bottom margin */
     }
-    
+
     #portfolio-display {
-        max-width: 90%; /* Portfolio container width */
+        max-width: 100%; /* Portfolio container width */
         margin: 0 auto;
         display: flex;
         justify-content: center;
@@ -1516,6 +1520,11 @@ section {
         flex-direction: column; /* Stack contents vertically */
         box-shadow: none !important; /* Prevent any box-shadow from being applied to the container */
         background-color: transparent !important; /* Ensure background is transparent */
+        padding: 0 1rem; /* Provide subtle breathing room */
+    }
+    #portfolio-display .live-music-grid.active,
+    #portfolio-display .visuals-grid.active {
+        gap: 1.75rem;
     }
 }
 

--- a/portfolio.html
+++ b/portfolio.html
@@ -83,44 +83,44 @@
                 <div class="image-grid live-music-grid active">
                     <div class="grid-item">
                         <picture class="portfolio-picture">
-                            <source srcset="images/optimized/portfolio_001-320-64a4d39d.avif" type="image/avif">
-                            <source srcset="images/optimized/portfolio_001-320-64a4d39d.webp" type="image/webp">
-                            <img src="images/optimized/portfolio_001-320-64a4d39d.jpeg" alt="Live music photography" loading="lazy">
+                            <source srcset="images/optimized/portfolio_001-640-64a4d39d.avif" type="image/avif">
+                            <source srcset="images/optimized/portfolio_001-640-64a4d39d.webp" type="image/webp">
+                            <img src="images/optimized/portfolio_001-640-64a4d39d.jpeg" alt="Live music photography" loading="lazy">
                         </picture>
                     </div>
                     <div class="grid-item">
                         <picture class="portfolio-picture">
-                            <source srcset="images/optimized/portfolio_002-320-c76ecc57.avif" type="image/avif">
-                            <source srcset="images/optimized/portfolio_002-320-c76ecc57.webp" type="image/webp">
-                            <img src="images/optimized/portfolio_002-320-c76ecc57.jpeg" alt="Live music photography" loading="lazy">
+                            <source srcset="images/optimized/portfolio_002-640-c76ecc57.avif" type="image/avif">
+                            <source srcset="images/optimized/portfolio_002-640-c76ecc57.webp" type="image/webp">
+                            <img src="images/optimized/portfolio_002-640-c76ecc57.jpeg" alt="Live music photography" loading="lazy">
                         </picture>
                     </div>
                     <div class="grid-item">
                         <picture class="portfolio-picture">
-                            <source srcset="images/optimized/portfolio_004-320-4ed4c03c.avif" type="image/avif">
-                            <source srcset="images/optimized/portfolio_004-320-4ed4c03c.webp" type="image/webp">
-                            <img src="images/optimized/portfolio_004-320-4ed4c03c.jpeg" alt="Live music photography" loading="lazy">
+                            <source srcset="images/optimized/portfolio_004-640-4ed4c03c.avif" type="image/avif">
+                            <source srcset="images/optimized/portfolio_004-640-4ed4c03c.webp" type="image/webp">
+                            <img src="images/optimized/portfolio_004-640-4ed4c03c.jpeg" alt="Live music photography" loading="lazy">
                         </picture>
                     </div>
                     <div class="grid-item">
                         <picture class="portfolio-picture">
-                            <source srcset="images/optimized/portfolio_011-320-66a1e26f.avif" type="image/avif">
-                            <source srcset="images/optimized/portfolio_011-320-66a1e26f.webp" type="image/webp">
-                            <img src="images/optimized/portfolio_011-320-66a1e26f.jpeg" alt="Live music photography" loading="lazy">
+                            <source srcset="images/optimized/portfolio_011-640-66a1e26f.avif" type="image/avif">
+                            <source srcset="images/optimized/portfolio_011-640-66a1e26f.webp" type="image/webp">
+                            <img src="images/optimized/portfolio_011-640-66a1e26f.jpeg" alt="Live music photography" loading="lazy">
                         </picture>
                     </div>
                     <div class="grid-item">
                         <picture class="portfolio-picture">
-                            <source srcset="images/optimized/portfolio_012-320-acbaaf1e.avif" type="image/avif">
-                            <source srcset="images/optimized/portfolio_012-320-acbaaf1e.webp" type="image/webp">
-                            <img src="images/optimized/portfolio_012-320-acbaaf1e.jpeg" alt="Live music photography" loading="lazy">
+                            <source srcset="images/optimized/portfolio_012-640-acbaaf1e.avif" type="image/avif">
+                            <source srcset="images/optimized/portfolio_012-640-acbaaf1e.webp" type="image/webp">
+                            <img src="images/optimized/portfolio_012-640-acbaaf1e.jpeg" alt="Live music photography" loading="lazy">
                         </picture>
                     </div>
                     <div class="grid-item">
                         <picture class="portfolio-picture">
-                            <source srcset="images/optimized/portfolio_016-320-e6412b59.avif" type="image/avif">
-                            <source srcset="images/optimized/portfolio_016-320-e6412b59.webp" type="image/webp">
-                            <img src="images/optimized/portfolio_016-320-e6412b59.jpeg" alt="Live music photography" loading="lazy">
+                            <source srcset="images/optimized/portfolio_016-640-e6412b59.avif" type="image/avif">
+                            <source srcset="images/optimized/portfolio_016-640-e6412b59.webp" type="image/webp">
+                            <img src="images/optimized/portfolio_016-640-e6412b59.jpeg" alt="Live music photography" loading="lazy">
                         </picture>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- adjust portfolio grid spacing to use more screen width and switch to a single column on small viewports
- load higher resolution 640px image assets so enlarged thumbnails remain sharp

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb2ee75f6083258b54a086dacf95b9