### PR TITLE
Fix Vercel deployment build output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ npm-debug.log*
 
 # Vercel local/project artifacts
 .vercel
+
+# Build output directory
+public/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "minify:css": "csso css/style.css --output css/style.min.css --source-map file",
     "minify:js": "terser js/script.js -o js/script.min.js --compress --mangle --source-map \"content=inline\"",
     "minify": "npm run minify:css && npm run minify:js",
-    "build": "npm run media && npm run images && npm run minify",
+    "build": "node scripts/build.js",
     "lint": "node --check js/script.js && node --check js/sw-register.js && node --check sw.js && node --check scripts/optimize-images.js && node --check scripts/generate-media-manifest.js && node --check api/contact.js",
     "test": "npm run lint",
     "ci": "npm run lint && npm run build",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const PUBLIC_DIR = 'public';
+
+console.log('Building for Vercel deployment...\n');
+
+// Step 1: Prepare output directory
+console.log('Step 1: Preparing build output directory');
+execSync('node scripts/prepare-build-output.js');
+
+// Step 2: Generate media manifest
+console.log('\nStep 2: Generating media manifest');
+process.chdir(PUBLIC_DIR);
+execSync('node ../scripts/generate-media-manifest.js');
+process.chdir('..');
+
+// Step 3: Optimize images
+console.log('\nStep 3: Optimizing images (this may take several minutes)');
+process.chdir(PUBLIC_DIR);
+execSync('node ../scripts/optimize-images.js');
+process.chdir('..');
+
+// Step 4: Minify assets
+console.log('\nStep 4: Minifying CSS and JavaScript');
+process.chdir(PUBLIC_DIR);
+execSync('csso css/style.css --output css/style.min.css --source-map file');
+execSync('terser js/script.js -o js/script.min.js --compress --mangle --source-map "content=inline"');
+process.chdir('..');
+
+console.log('\n✓ Build completed successfully!');
+console.log(`✓ Output ready in ${PUBLIC_DIR}/ directory for deployment`);

--- a/scripts/prepare-build-output.js
+++ b/scripts/prepare-build-output.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const PUBLIC_DIR = 'public';
+const SOURCE_DIR = '.';
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function copyDir(src, dest, options = {}) {
+  const { ignore = [] } = options;
+
+  if (!fs.existsSync(src)) return;
+
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (ignore.includes(entry.name)) continue;
+
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      ensureDir(destPath);
+      copyDir(srcPath, destPath, options);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+function copyFile(src, dest) {
+  const dir = path.dirname(dest);
+  ensureDir(dir);
+  fs.copyFileSync(src, dest);
+}
+
+// Clean and create public directory
+if (fs.existsSync(PUBLIC_DIR)) {
+  fs.rmSync(PUBLIC_DIR, { recursive: true, force: true });
+}
+ensureDir(PUBLIC_DIR);
+
+// Copy all necessary files and directories
+const ignorePatterns = [
+  'node_modules',
+  '.git',
+  '.github',
+  '.vercel',
+  'public',
+  'scripts',
+  '__tests__',
+  '.codex',
+  '.vscode',
+  'docs',
+  'images/portfolio', // We'll copy optimized versions later
+];
+
+// Copy root files
+const rootFiles = fs.readdirSync(SOURCE_DIR);
+for (const file of rootFiles) {
+  if (ignorePatterns.includes(file)) continue;
+  if (file.startsWith('.') && !['_headers', '.htaccess'].includes(file)) continue;
+
+  const src = path.join(SOURCE_DIR, file);
+  const dest = path.join(PUBLIC_DIR, file);
+  const stat = fs.statSync(src);
+
+  if (stat.isDirectory()) {
+    ensureDir(dest);
+    copyDir(src, dest);
+  } else if (stat.isFile()) {
+    copyFile(src, dest);
+  }
+}
+
+// Copy HTML files
+['index.html', 'about.html', 'contact.html', 'portfolio.html'].forEach(file => {
+  if (fs.existsSync(file)) {
+    copyFile(file, path.join(PUBLIC_DIR, file));
+  }
+});
+
+// Copy special files
+if (fs.existsSync('_headers')) copyFile('_headers', path.join(PUBLIC_DIR, '_headers'));
+if (fs.existsSync('.htaccess')) copyFile('.htaccess', path.join(PUBLIC_DIR, '.htaccess'));
+
+console.log('Build output prepared in public/ directory');

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "npm ci",
   "buildCommand": "npm run build",
+  "outputDirectory": "public",
   "rewrites": [
     {
       "source": "/about",


### PR DESCRIPTION
## Problem
The Vercel deployment was failing with:
```
Error: No Output Directory named "dist" found after the Build completed.
```

This occurred because:
- The build scripts were modifying files in place (root directory)
- Vercel expects a dedicated output directory (`dist` or `public`) after the build completes
- No output directory was being created, causing the deployment to fail

## Solution
Created a proper build output workflow:

1. **scripts/prepare-build-output.js** - Copies all source files to a `public/` directory
2. **scripts/build.js** - Orchestrates the full build process:
   - Copies files to `public/`
   - Generates media manifest in `public/`
   - Optimizes images in `public/`
   - Minifies CSS and JS in `public/`
3. Updated `vercel.json` to specify `outputDirectory: "public"`
4. Updated `package.json` to use the new build script
5. Added `public/` to `.gitignore` to exclude generated files from git

## Result
The build now produces a clean, deployable `public/` directory that Vercel expects, resolving the deployment failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMsw1hjAUVRnDZL7DGe6LD)_