### PR TITLE
Fix portfolio videos + navigation enhancements

### DIFF
--- a/scripts/update-video-csp.js
+++ b/scripts/update-video-csp.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// @ts-check
+
+/**
+ * Updates CSP media-src directive across all config/HTML files to allow external video hosting.
+ * Usage: node scripts/update-video-csp.js https://res.cloudinary.com
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CDN_DOMAIN = process.argv[2];
+
+if (!CDN_DOMAIN) {
+  console.error('Usage: node scripts/update-video-csp.js <CDN_DOMAIN>');
+  console.error('Example: node scripts/update-video-csp.js https://res.cloudinary.com');
+  process.exit(1);
+}
+
+const ROOT = process.cwd();
+
+// Extract domain (e.g., "https://res.cloudinary.com" -> "res.cloudinary.com")
+const domainMatch = CDN_DOMAIN.match(/https?:\/\/([^\/]+)/);
+const domain = domainMatch ? domainMatch[1] : CDN_DOMAIN;
+const cdnOrigin = `https://${domain}`;
+
+const originalCSP = "media-src 'self' data:";
+const newCSP = `media-src 'self' data: ${cdnOrigin}`;
+
+// Files to update
+const files = [
+  {
+    path: path.join(ROOT, 'vercel.json'),
+    pattern: /"Content-Security-Policy":\s*"([^"]*media-src[^"]*)"/,
+    replacer: (match) => {
+      return match.replace(originalCSP, newCSP);
+    }
+  },
+  {
+    path: path.join(ROOT, '_headers'),
+    pattern: /Content-Security-Policy: ([^\n]*media-src[^\n]*)/,
+    replacer: (match) => {
+      return match.replace(originalCSP, newCSP);
+    }
+  },
+  {
+    path: path.join(ROOT, 'portfolio.html'),
+    pattern: /<meta http-equiv="Content-Security-Policy" content="([^"]*)"/,
+    replacer: (match) => {
+      return match.replace(originalCSP, newCSP);
+    }
+  },
+  {
+    path: path.join(ROOT, 'index.html'),
+    pattern: /<meta http-equiv="Content-Security-Policy" content="([^"]*)"/,
+    replacer: (match) => {
+      return match.replace(originalCSP, newCSP);
+    }
+  },
+  {
+    path: path.join(ROOT, 'about.html'),
+    pattern: /<meta http-equiv="Content-Security-Policy" content="([^"]*)"/,
+    replacer: (match) => {
+      return match.replace(originalCSP, newCSP);
+    }
+  },
+  {
+    path: path.join(ROOT, 'contact.html'),
+    pattern: /<meta http-equiv="Content-Security-Policy" content="([^"]*)"/,
+    replacer: (match) => {
+      return match.replace(originalCSP, newCSP);
+    }
+  }
+];
+
+let updatedCount = 0;
+
+for (const file of files) {
+  if (!fs.existsSync(file.path)) {
+    console.warn(`Skipping ${file.path} (not found)`);
+    continue;
+  }
+
+  let content = fs.readFileSync(file.path, 'utf8');
+  const originalContent = content;
+
+  // Replace all occurrences
+  content = content.replace(file.pattern, (match) => {
+    return file.replacer(match);
+  });
+
+  if (content !== originalContent) {
+    fs.writeFileSync(file.path, content);
+    console.log(`Updated ${path.relative(ROOT, file.path)}`);
+    updatedCount++;
+  } else {
+    console.warn(`No changes in ${path.relative(ROOT, file.path)}`);
+  }
+}
+
+console.log(`\nCSP updated to allow media from: ${cdnOrigin}`);
+console.log(`Files updated: ${updatedCount}`);
+console.log('\nNext steps:');
+console.log('1. Fill in data/video-sources.json with CDN URLs and poster paths');
+console.log('2. Run: npm run media');
+console.log('3. Run: npm run build');


### PR DESCRIPTION
## Overview

This PR combines multiple enhancements to the portfolio:

### 1. Video Fix Infrastructure (Ready for CDN URLs)
**Problem:** Portfolio videos show a black player with no playback. Root cause: Git LFS pointer files aren't resolved by Vercel.

**Solution:** Build-safe CDN hosting mechanism
- **`data/video-sources.json` (new)** — User-editable override map for CDN URLs + posters. Entries with empty `src` fall back to local files.
- **`scripts/generate-media-manifest.js`** — Enhanced to read and apply overrides during manifest regeneration, so external URLs survive every build.
- **`js/script.js`** — Lightbox now carries poster through; failed videos show graceful `.media-fallback` placeholder instead of black box.
- **`css/style.css`** — Styling for fallback placeholder.
- **`scripts/update-video-csp.js` (new)** — Helper script to batch-update CSP headers once CDN domain is chosen.

**Status:** Infrastructure complete and tested. Awaiting CDN URLs + posters from user.

### 2. Navigation Button Enhancements  
- Smoother hover effects with `filter: brightness` instead of `translateY`
- Clearer active states with persistent indicators
- Improved keyboard accessibility with `focus-visible` outlines
- GPU-accelerated transforms
- Mobile touch target improvements
- Respect for `prefers-reduced-motion`

### 3. Redesign Preview
- Added `redesign-preview.html` — drop-in concert-pit neon zine homepage concept
- No impact on existing site; preview-only

## Test Plan

- [x] Lint passes
- [x] Video override mechanism verified (test CDN URL applied successfully)
- [x] Build succeeds with empty override template
- [ ] **Pending user action:** Provide CDN URLs and poster paths
- [ ] **Pending:** Update CSP in `vercel.json`, `_headers`, and HTML metas (via `update-video-csp.js`)

## What's Needed to Complete Video Playback

1. Upload clips to a video CDN (Cloudinary/Bunny/Mux/Vercel Blob recommended)
2. Fill in `data/video-sources.json` with CDN URLs and poster paths
3. Run: `node scripts/update-video-csp.js <CDN_ORIGIN>` (e.g., `https://res.cloudinary.com`)
4. Verify: grid shows posters, lightbox plays from CDN, no CSP violations

---
*Generated by Claude Code*


---
_Generated by [Claude Code](https://claude.ai/code/session_011MQsNxJ2zqdANiuQ1WcHZ2)_